### PR TITLE
bugfix-tube-barcode-not-choosing-right-template

### DIFF
--- a/app/controllers/barcode_labels_controller.rb
+++ b/app/controllers/barcode_labels_controller.rb
@@ -13,7 +13,6 @@ class BarcodeLabelsController < ApplicationController
 
   # Creates a label
   def create_label(details)
-    details[:type] = params[:labeltemplatetype]
     Sanger::Barcode::Printing::Label.new(details)
   end
   private :create_label

--- a/app/controllers/barcode_labels_controller.rb
+++ b/app/controllers/barcode_labels_controller.rb
@@ -13,7 +13,7 @@ class BarcodeLabelsController < ApplicationController
 
   # Creates a label
   def create_label(details)
-    details[:type] = "custom-labels"
+    details[:type] = params[:labeltemplatetype]
     Sanger::Barcode::Printing::Label.new(details)
   end
   private :create_label

--- a/app/models/presenters.rb
+++ b/app/models/presenters.rb
@@ -36,7 +36,7 @@ module Presenters
     end
 
     def label_type
-      ""
+      yield nil
     end
 
   end
@@ -87,7 +87,7 @@ module Presenters
     }
 
     def label_type
-      "custom-labels"
+      yield "custom-labels"
     end
 
     def robot_name

--- a/app/models/presenters.rb
+++ b/app/models/presenters.rb
@@ -35,6 +35,10 @@ module Presenters
       nil
     end
 
+    def label_type
+      ""
+    end
+
   end
 
   class PlatePresenter
@@ -81,6 +85,10 @@ module Presenters
     class_inheritable_reader    :robot_controlled_states
     write_inheritable_attribute :robot_controlled_states, {
     }
+
+    def label_type
+      "custom-labels"
+    end
 
     def robot_name
       robot_controlled_states[labware.state.to_sym]

--- a/app/views/labware/_individual_barcode_printing_form.html.erb
+++ b/app/views/labware/_individual_barcode_printing_form.html.erb
@@ -1,8 +1,12 @@
 <%= form_for(barcode, :url => print_individual_label_path, :as => :label, :html => {:method => :post}) do |f| %>
   <%# Hide the details of what is in the label to be printed %>
   <ul data-role="listview" data-inset="true">
-    <%= hidden_field_tag :labeltemplatetype, @presenter.label_type %>
     <%= hidden_field_tag(:redirect_to, redirection_url) %>
+
+    <% @presenter.label_type do |type| %>
+      <%= hidden_field_tag :type, type %>
+    <% end %>
+    
     <%= f.hidden_field :prefix %>
     <%= f.hidden_field :number %>
     <%= f.hidden_field :study, :value => text %>

--- a/app/views/labware/_individual_barcode_printing_form.html.erb
+++ b/app/views/labware/_individual_barcode_printing_form.html.erb
@@ -1,6 +1,7 @@
 <%= form_for(barcode, :url => print_individual_label_path, :as => :label, :html => {:method => :post}) do |f| %>
   <%# Hide the details of what is in the label to be printed %>
   <ul data-role="listview" data-inset="true">
+    <%= hidden_field_tag :labeltemplatetype, @presenter.label_type %>
     <%= hidden_field_tag(:redirect_to, redirection_url) %>
     <%= f.hidden_field :prefix %>
     <%= f.hidden_field :number %>

--- a/app/views/labware/_individual_barcode_printing_form.html.erb
+++ b/app/views/labware/_individual_barcode_printing_form.html.erb
@@ -4,7 +4,7 @@
     <%= hidden_field_tag(:redirect_to, redirection_url) %>
 
     <% @presenter.label_type do |type| %>
-      <%= hidden_field_tag :type, type %>
+      <%= f.hidden_field :type, type %>
     <% end %>
     
     <%= f.hidden_field :prefix %>

--- a/app/views/labware/_individual_barcode_printing_form.html.erb
+++ b/app/views/labware/_individual_barcode_printing_form.html.erb
@@ -4,7 +4,7 @@
     <%= hidden_field_tag(:redirect_to, redirection_url) %>
 
     <% @presenter.label_type do |type| %>
-      <%= f.hidden_field :type, type %>
+      <%= f.hidden_field :type, :value => type %>
     <% end %>
     
     <%= f.hidden_field :prefix %>

--- a/app/views/labware/_multiple_barcodes_printing_form.html.erb
+++ b/app/views/labware/_multiple_barcodes_printing_form.html.erb
@@ -5,7 +5,7 @@
     <% barcodes.each_with_index do |barcode, index| %>
       <%= f.fields_for(index.to_s.to_sym, barcode) do |barcode_form| %>
         <% @presenter.label_type do |type| %>
-          <%= barcode_form.hidden_field :type, type %>
+          <%= barcode_form.hidden_field :type, :value => type %>
         <% end %>
         <%= barcode_form.hidden_field(:prefix) %>
         <%= barcode_form.hidden_field(:number) %>

--- a/app/views/labware/_multiple_barcodes_printing_form.html.erb
+++ b/app/views/labware/_multiple_barcodes_printing_form.html.erb
@@ -2,12 +2,11 @@
   <%# Hide the details of what is in the label to be printed %>
     <%= hidden_field_tag(:redirect_to, redirection_url) %>
 
-    <% @presenter.label_type do |type| %>
-      <%= hidden_field_tag :type, type %>
-    <% end %>
-
     <% barcodes.each_with_index do |barcode, index| %>
       <%= f.fields_for(index.to_s.to_sym, barcode) do |barcode_form| %>
+        <% @presenter.label_type do |type| %>
+          <%= barcode_form.hidden_field :type, type %>
+        <% end %>
         <%= barcode_form.hidden_field(:prefix) %>
         <%= barcode_form.hidden_field(:number) %>
         <%= barcode_form.hidden_field(:study, :value => text[index]) %>

--- a/app/views/labware/_multiple_barcodes_printing_form.html.erb
+++ b/app/views/labware/_multiple_barcodes_printing_form.html.erb
@@ -2,7 +2,9 @@
   <%# Hide the details of what is in the label to be printed %>
     <%= hidden_field_tag(:redirect_to, redirection_url) %>
 
-    <%= hidden_field_tag :labeltemplatetype, @presenter.label_type %>
+    <% @presenter.label_type do |type| %>
+      <%= hidden_field_tag :type, type %>
+    <% end %>
 
     <% barcodes.each_with_index do |barcode, index| %>
       <%= f.fields_for(index.to_s.to_sym, barcode) do |barcode_form| %>

--- a/app/views/labware/_multiple_barcodes_printing_form.html.erb
+++ b/app/views/labware/_multiple_barcodes_printing_form.html.erb
@@ -2,6 +2,8 @@
   <%# Hide the details of what is in the label to be printed %>
     <%= hidden_field_tag(:redirect_to, redirection_url) %>
 
+    <%= hidden_field_tag :labeltemplatetype, @presenter.label_type %>
+
     <% barcodes.each_with_index do |barcode, index| %>
       <%= f.fields_for(index.to_s.to_sym, barcode) do |barcode_form| %>
         <%= barcode_form.hidden_field(:prefix) %>


### PR DESCRIPTION
Obtains name of type of template from the presenter instead of the controller to avoid the tube to select the same template as the plates
