### PR TITLE
Do not yield when no label type

### DIFF
--- a/app/models/presenters.rb
+++ b/app/models/presenters.rb
@@ -36,7 +36,7 @@ module Presenters
     end
 
     def label_type
-      yield nil
+      nil
     end
 
   end


### PR DESCRIPTION
We don't want a label_type field, so we don't yield. If we
yield nil we still run the block.
