### PR TITLE
Lib Norm plate uses QC state changer

### DIFF
--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -321,6 +321,7 @@ namespace :config do
 
           presenters['Lib Norm'].merge!(
             :presenter_class => 'Presenters::QcCompletablePresenter',
+            :state_changer_class => 'StateChangers::QcCompletablePlateStateChanger',
             :robot_controlled_states => { :pending => 'pcr-xp-lib-norm' }
           )
 


### PR DESCRIPTION
If we have failed wells when we qc complete a plate it causes
issues, unless we filter out failed wells from the state
change.
