### PR TITLE
Mover overide method onto presenter from state changer

### DIFF
--- a/app/models/presenters/qc_completable_presenter.rb
+++ b/app/models/presenters/qc_completable_presenter.rb
@@ -14,5 +14,12 @@ module Presenters
       :failed      => [ 'labware-summary-button' ]
     }
 
+    private
+
+    def suitable_robots
+      @suitable_robots ||= labware.state == 'passed' ? [] : Settings.robots.select {|key,config| suitable_for_plate?(config) }
+    end
+
+
   end
 end

--- a/app/models/state_changers/qc_completable_plate_state_changer.rb
+++ b/app/models/state_changers/qc_completable_plate_state_changer.rb
@@ -47,13 +47,6 @@ module StateChangers
     def passive_state_change!(state_details)
       api.state_change.create!(state_details)
     end
-
-    private
-
-    def suitable_robots
-      @suitable_robots ||= labware.state == 'passed' ? [] : Settings.robots.select {|key,config| suitable_for_plate?(config) }
-    end
-
   end
 
   def self.lookup_for(purpose_uuid)


### PR DESCRIPTION
When testing the previous commit locally the development
robot config was out-of-sync and so there was no robot
to handle the QC tranfer. This gave the mistaken impression
that my fix worked.
